### PR TITLE
Allow task description to wrap

### DIFF
--- a/data/glade/task-dialog.glade
+++ b/data/glade/task-dialog.glade
@@ -895,7 +895,7 @@
 		      <property name="overwrite">False</property>
 		      <property name="accepts_tab">True</property>
 		      <property name="justification">GTK_JUSTIFY_LEFT</property>
-		      <property name="wrap_mode">GTK_WRAP_NONE</property>
+		      <property name="wrap_mode">GTK_WRAP_WORD</property>
 		      <property name="cursor_visible">True</property>
 		      <property name="pixels_above_lines">0</property>
 		      <property name="pixels_below_lines">0</property>


### PR DESCRIPTION
When using planner to store more than just very brief information about tasks, editing the task description is a poor user experience due to the lack of line wr
apping. This commit favours GTK_WRAP_WORD for GTK_WRAP_NONE.